### PR TITLE
Fix documentation image paths

### DIFF
--- a/doc/q4_doc.md
+++ b/doc/q4_doc.md
@@ -25,7 +25,7 @@ gray.save("gray_image.jpg")
 ```
 Saved file: `gray_image.jpg`
 
-![Gray Image](gray_image.jpg)
+![Gray Image](../gray_image.jpg)
 
 ## 3. Resize to 300×300 and rotate 45°
 ```python
@@ -36,9 +36,9 @@ rotated.save("rotated_45.png")
 ```
 Saved files: `resized_300x300.png`, `rotated_45.png`
 
-![Resized 300x300](resized_300x300.png)
+![Resized 300x300](../resized_300x300.png)
 
-![Rotated 45°](rotated_45.png)
+![Rotated 45°](../rotated_45.png)
 
 ## 4. Apply BLUR and SHARPEN filters
 ```python
@@ -49,9 +49,9 @@ sharpened.save("pil_sharpen.png")
 ```
 Saved files: `pil_blur.png`, `pil_sharpen.png`
 
-![PIL Blur](pil_blur.png)
+![PIL Blur](../pil_blur.png)
 
-![PIL Sharpen](pil_sharpen.png)
+![PIL Sharpen](../pil_sharpen.png)
 
 ## 5. OpenCV image info
 ```python
@@ -73,7 +73,7 @@ cv2.imwrite("output_gray.jpg", gray)
 ```
 Saved file: `output_gray.jpg`
 
-![OpenCV Gray](output_gray.jpg)
+![OpenCV Gray](../output_gray.jpg)
 
 ## 7. Display original and grayscale side by side
 ```python
@@ -95,9 +95,9 @@ cv2.imwrite("opencv_center_crop_100x100.jpg", crop)
 ```
 Saved files: `opencv_half.jpg`, `opencv_center_crop_100x100.jpg`
 
-![OpenCV Half](opencv_half.jpg)
+![OpenCV Half](../opencv_half.jpg)
 
-![OpenCV Center Crop 100x100](opencv_center_crop_100x100.jpg)
+![OpenCV Center Crop 100x100](../opencv_center_crop_100x100.jpg)
 
 ## 9. Gaussian blur and Canny edge detection
 ```python

--- a/doc/q5_doc.md
+++ b/doc/q5_doc.md
@@ -11,7 +11,7 @@ cv2.imwrite(f"{outdir}/rotated_45.jpg", rotated)
 ```
 Saved file: `q5/outputs/rotated_45.jpg`
 
-![Rotated 45°](q5/outputs/rotated_45.jpg)
+![Rotated 45°](../q5/outputs/rotated_45.jpg)
 
 ## 2. Convert color image to black & white (binary)
 ```python
@@ -21,7 +21,7 @@ cv2.imwrite(f"{outdir}/binary.jpg", binary)
 ```
 Saved file: `q5/outputs/binary.jpg`
 
-![Binary Image](q5/outputs/binary.jpg)
+![Binary Image](../q5/outputs/binary.jpg)
 
 ## 3. Flip image horizontally and vertically
 ```python
@@ -32,9 +32,9 @@ cv2.imwrite(f"{outdir}/flip_vertical.jpg", flip_v)
 ```
 Saved files: `q5/outputs/flip_horizontal.jpg`, `q5/outputs/flip_vertical.jpg`
 
-![Flipped Horizontal](q5/outputs/flip_horizontal.jpg)
+![Flipped Horizontal](../q5/outputs/flip_horizontal.jpg)
 
-![Flipped Vertical](q5/outputs/flip_vertical.jpg)
+![Flipped Vertical](../q5/outputs/flip_vertical.jpg)
 
 ## 4. Crop the center portion of the image
 ```python
@@ -45,7 +45,7 @@ cv2.imwrite(f"{outdir}/center_crop.jpg", crop)
 ```
 Saved file: `q5/outputs/center_crop.jpg`
 
-![Center Crop](q5/outputs/center_crop.jpg)
+![Center Crop](../q5/outputs/center_crop.jpg)
 
 ## 5. Draw rectangle, circle, and line
 ```python
@@ -57,7 +57,7 @@ cv2.imwrite(f"{outdir}/shapes.jpg", draw)
 ```
 Saved file: `q5/outputs/shapes.jpg`
 
-![Shapes](q5/outputs/shapes.jpg)
+![Shapes](../q5/outputs/shapes.jpg)
 
 ## 6. Convert image to HSV color space
 ```python
@@ -66,7 +66,7 @@ cv2.imwrite(f"{outdir}/hsv.jpg", hsv)
 ```
 Saved file: `q5/outputs/hsv.jpg`
 
-![HSV Image](q5/outputs/hsv.jpg)
+![HSV Image](../q5/outputs/hsv.jpg)
 
 ## 7. Apply Gaussian blur
 ```python
@@ -75,7 +75,7 @@ cv2.imwrite(f"{outdir}/blurred.jpg", blur)
 ```
 Saved file: `q5/outputs/blurred.jpg`
 
-![Gaussian Blur](q5/outputs/blurred.jpg)
+![Gaussian Blur](../q5/outputs/blurred.jpg)
 
 ## 8. Highlight edges with Canny edge detector
 ```python
@@ -84,5 +84,5 @@ cv2.imwrite(f"{outdir}/edges.jpg", edges)
 ```
 Saved file: `q5/outputs/edges.jpg`
 
-![Canny Edges](q5/outputs/edges.jpg)
+![Canny Edges](../q5/outputs/edges.jpg)
 


### PR DESCRIPTION
## Summary
- Correct image links in Q4 documentation by using paths relative to the repo root
- Update Q5 documentation image references to ensure local images render

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be680e9654832c884d86a0e9bf4622